### PR TITLE
Speed up PNG and improve JPEG quality

### DIFF
--- a/PhotoMetadataPatch.cs
+++ b/PhotoMetadataPatch.cs
@@ -99,14 +99,14 @@ public partial class ResoniteScreenshotExtensions : ResoniteMod
                 switch (format)
                 {
                     case ImageFormat.JPEG:
-                        bmp.Save(dstPath, FREE_IMAGE_FORMAT.FIF_JPEG, FREE_IMAGE_SAVE_FLAGS.JPEG_QUALITYSUPERB);
+                        bmp.Save(dstPath, FREE_IMAGE_FORMAT.FIF_JPEG, (FREE_IMAGE_SAVE_FLAGS)95 | FREE_IMAGE_SAVE_FLAGS.JPEG_SUBSAMPLING_444 | FREE_IMAGE_SAVE_FLAGS.JPEG_PROGRESSIVE);
                         break;
                     case ImageFormat.WEBP:
                         FREE_IMAGE_SAVE_FLAGS quality = (_config?.GetValue(LossyWebpKey) ?? false) ? (FREE_IMAGE_SAVE_FLAGS)_config.GetValue(LossyWebpQualityKey) : FREE_IMAGE_SAVE_FLAGS.WEBP_LOSSLESS;
                         bmp.Save(dstPath, FreeImage.GetFIFFromFormat("webp"), quality);
                         break;
                     case ImageFormat.PNG:
-                        bmp.Save(dstPath, FREE_IMAGE_FORMAT.FIF_PNG, FREE_IMAGE_SAVE_FLAGS.PNG_Z_BEST_COMPRESSION);
+                        bmp.Save(dstPath, FREE_IMAGE_FORMAT.FIF_PNG, (FREE_IMAGE_SAVE_FLAGS)4);
                         break;
                 }
             }


### PR DESCRIPTION
15x faster saving PNG and 2x smaller JPEGs.

PNG
Seconds | Old | New | Speed | Size
| :---: | :---: | :---: | :---: | :---: |
1080p | 7.77 | 0.53 | 14.66x | +10%
1440p | 13.67 | 0.91 | 15.02x | +10%
2160p | 31.21 | 1.92 | 16.26x | +14%
4320p | 126.4 | 7.63 | 16.56x | +20%

JPEG
4K | Seconds | Size (MB) | SSIMU2 (Quality)
| :---: | :---: | :---: | :---: |
Old | 0.26 | 3.24 | 87.19
New | 0.46 | 1.31 | 86.98