### PR TITLE
Add Linux compatibility, fallback metadata injection & code cleanup

### DIFF
--- a/DataTreeUtils.cs
+++ b/DataTreeUtils.cs
@@ -1,4 +1,4 @@
-﻿using Elements.Core;
+using Elements.Core;
 using FrooxEngine;
 using Newtonsoft.Json;
 using System.IO;
@@ -11,7 +11,7 @@ public static class DataTreeUtils
     public static void LoadComponent(IComponent component, SavedGraph graph)
     {
         var dict = graph.Root;
-        var control = new LoadControl(component.Slot.World, new ReferenceTranslator(), default, null);
+        var control = new LoadControl(component.Slot.World, new ReferenceTranslator(), default, null!);
         control.TryLoadVersion(dict);
         var flags = dict.TryGetDictionary("FeatureFlags");
         if (flags != null)
@@ -37,7 +37,7 @@ public static class DataTreeUtils
     {
         var sr = new StringReader(json);
         var reader = new JsonTextReader(sr);
-        var node = (DataTreeNode)AccessTools.Method(typeof(DataTreeConverter), "Read").Invoke(null, new object[] { reader });
+        var node = (DataTreeNode?)AccessTools.Method(typeof(DataTreeConverter), "Read").Invoke(null, new object[] { reader });
         if (node != null)
         {
             return new SavedGraph((DataTreeDictionary)node);

--- a/MetadataInjector.cs
+++ b/MetadataInjector.cs
@@ -193,12 +193,12 @@ public static class MetadataInjector
         var vp8xChunk = chunks.Find(c => c.FourCC == "VP8X");
         if (vp8xChunk != null)
         {
-            vp8xChunk.Data[0] |= 0x10; // XMP flag
+            vp8xChunk.Data[0] |= 0x04; // XMP flag (0x04)
         }
         else
         {
             byte[] vp8xData = new byte[10];
-            vp8xData[0] = (byte)(0x10 | (isTransparent ? 0x02 : 0x00));
+            vp8xData[0] = (byte)(0x04 | (isTransparent ? 0x10 : 0x00)); // XMP_FLAG (0x04) | (ALPHA_FLAG (0x10) if transparent)
             int wMinusOne = width - 1;
             int hMinusOne = height - 1;
             vp8xData[4] = (byte)(wMinusOne & 0xFF);

--- a/MetadataInjector.cs
+++ b/MetadataInjector.cs
@@ -1,0 +1,244 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using FrooxEngine;
+
+namespace ResoniteScreenshotExtensions;
+
+public static class MetadataInjector
+{
+    public static byte[] InjectXmp(byte[] originalBytes, ResoniteScreenshotExtensions.ImageFormat format, Metadata metadata, int width, int height, bool isTransparent)
+    {
+        try
+        {
+            string xmpXml = XmpMetadata.GetXmpXmlString(metadata);
+            switch (format)
+            {
+                case ResoniteScreenshotExtensions.ImageFormat.JPEG:
+                    return InjectIntoJpeg(originalBytes, xmpXml);
+                case ResoniteScreenshotExtensions.ImageFormat.PNG:
+                    return InjectIntoPng(originalBytes, xmpXml);
+                case ResoniteScreenshotExtensions.ImageFormat.WEBP:
+                    return InjectIntoWebp(originalBytes, xmpXml, width, height, isTransparent);
+            }
+        }
+        catch (Exception ex)
+        {
+            ResoniteScreenshotExtensions.Error($"Failed to inject XMP metadata: {ex}");
+        }
+        return originalBytes;
+    }
+
+    private static byte[] InjectIntoJpeg(byte[] originalBytes, string xmpXml)
+    {
+        if (originalBytes.Length < 4 || originalBytes[0] != 0xFF || originalBytes[1] != 0xD8)
+        {
+            throw new InvalidDataException("Invalid JPEG SOI marker.");
+        }
+
+        byte[] xmpBytes = Encoding.UTF8.GetBytes(xmpXml);
+        byte[] namespaceBytes = Encoding.UTF8.GetBytes("http://ns.adobe.com/xap/1.0/\0");
+        int payloadLength = namespaceBytes.Length + xmpBytes.Length;
+        int segmentLength = payloadLength + 2;
+
+        if (segmentLength > 65535)
+        {
+            throw new InvalidOperationException("XMP metadata is too large for JPEG APP1 segment.");
+        }
+
+        using (var ms = new MemoryStream())
+        {
+            ms.WriteByte(0xFF);
+            ms.WriteByte(0xD8);
+
+            ms.WriteByte(0xFF);
+            ms.WriteByte(0xE1);
+            ms.WriteByte((byte)((segmentLength >> 8) & 0xFF));
+            ms.WriteByte((byte)(segmentLength & 0xFF));
+            ms.Write(namespaceBytes, 0, namespaceBytes.Length);
+            ms.Write(xmpBytes, 0, xmpBytes.Length);
+
+            ms.Write(originalBytes, 2, originalBytes.Length - 2);
+
+            return ms.ToArray();
+        }
+    }
+
+    private static byte[] InjectIntoPng(byte[] originalBytes, string xmpXml)
+    {
+        byte[] signature = { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
+        for (int i = 0; i < signature.Length; i++)
+        {
+            if (originalBytes[i] != signature[i])
+                throw new InvalidDataException("Invalid PNG signature.");
+        }
+
+        byte[] keywordBytes = Encoding.UTF8.GetBytes("XML:com.adobe.xmp\0");
+        byte[] xmpBytes = Encoding.UTF8.GetBytes(xmpXml);
+        byte[] chunkData = new byte[keywordBytes.Length + 4 + xmpBytes.Length];
+
+        Buffer.BlockCopy(keywordBytes, 0, chunkData, 0, keywordBytes.Length);
+        chunkData[keywordBytes.Length] = 0;     // Compression flag
+        chunkData[keywordBytes.Length + 1] = 0; // Compression method
+        chunkData[keywordBytes.Length + 2] = 0; // Language tag
+        chunkData[keywordBytes.Length + 3] = 0; // Translated keyword
+        Buffer.BlockCopy(xmpBytes, 0, chunkData, keywordBytes.Length + 4, xmpBytes.Length);
+
+        byte[] typeBytes = Encoding.UTF8.GetBytes("iTXt");
+        uint crc = CalculateCrc32(typeBytes, chunkData);
+
+        using (var ms = new MemoryStream())
+        {
+            ms.Write(originalBytes, 0, 33); // Signature (8 bytes) + IHDR (25 bytes)
+
+            byte[] lenBytes = {
+                (byte)((chunkData.Length >> 24) & 0xFF),
+                (byte)((chunkData.Length >> 16) & 0xFF),
+                (byte)((chunkData.Length >> 8) & 0xFF),
+                (byte)(chunkData.Length & 0xFF)
+            };
+            ms.Write(lenBytes, 0, lenBytes.Length);
+            ms.Write(typeBytes, 0, typeBytes.Length);
+            ms.Write(chunkData, 0, chunkData.Length);
+
+            byte[] crcBytes = {
+                (byte)((crc >> 24) & 0xFF),
+                (byte)((crc >> 16) & 0xFF),
+                (byte)((crc >> 8) & 0xFF),
+                (byte)(crc & 0xFF)
+            };
+            ms.Write(crcBytes, 0, crcBytes.Length);
+
+            ms.Write(originalBytes, 33, originalBytes.Length - 33);
+
+            return ms.ToArray();
+        }
+    }
+
+    private static uint CalculateCrc32(byte[] typeBytes, byte[] dataBytes)
+    {
+        uint[] table = new uint[256];
+        for (uint i = 0; i < 256; i++)
+        {
+            uint entry = i;
+            for (int j = 0; j < 8; j++)
+            {
+                if ((entry & 1) == 1)
+                    entry = (entry >> 1) ^ 0xEDB88320;
+                else
+                    entry >>= 1;
+            }
+            table[i] = entry;
+        }
+
+        uint crc = 0xFFFFFFFF;
+        foreach (byte b in typeBytes)
+        {
+            crc = (crc >> 8) ^ table[(crc ^ b) & 0xFF];
+        }
+        foreach (byte b in dataBytes)
+        {
+            crc = (crc >> 8) ^ table[(crc ^ b) & 0xFF];
+        }
+        return crc ^ 0xFFFFFFFF;
+    }
+
+    private class WebpChunk
+    {
+        public string FourCC;
+        public byte[] Data;
+
+        public WebpChunk(string fourCC, byte[] data)
+        {
+            FourCC = fourCC;
+            Data = data;
+        }
+    }
+
+    private static byte[] InjectIntoWebp(byte[] originalBytes, string xmpXml, int width, int height, bool isTransparent)
+    {
+        if (originalBytes.Length < 12 ||
+            originalBytes[0] != 'R' || originalBytes[1] != 'I' || originalBytes[2] != 'F' || originalBytes[3] != 'F' ||
+            originalBytes[8] != 'W' || originalBytes[9] != 'E' || originalBytes[10] != 'B' || originalBytes[11] != 'P')
+        {
+            throw new InvalidDataException("Invalid WebP container.");
+        }
+
+        var chunks = new List<WebpChunk>();
+        int offset = 12;
+        while (offset < originalBytes.Length)
+        {
+            if (offset + 8 > originalBytes.Length)
+            {
+                break;
+            }
+
+            string fourCC = Encoding.ASCII.GetString(originalBytes, offset, 4);
+            uint size = BitConverter.ToUInt32(originalBytes, offset + 4);
+            offset += 8;
+
+            if (offset + size > originalBytes.Length)
+            {
+                break;
+            }
+
+            byte[] chunkData = new byte[size];
+            Buffer.BlockCopy(originalBytes, offset, chunkData, 0, (int)size);
+            chunks.Add(new WebpChunk(fourCC, chunkData));
+
+            offset += (int)((size + 1) & ~1);
+        }
+
+        var vp8xChunk = chunks.Find(c => c.FourCC == "VP8X");
+        if (vp8xChunk != null)
+        {
+            vp8xChunk.Data[0] |= 0x10; // XMP flag
+        }
+        else
+        {
+            byte[] vp8xData = new byte[10];
+            vp8xData[0] = (byte)(0x10 | (isTransparent ? 0x02 : 0x00));
+            int wMinusOne = width - 1;
+            int hMinusOne = height - 1;
+            vp8xData[4] = (byte)(wMinusOne & 0xFF);
+            vp8xData[5] = (byte)((wMinusOne >> 8) & 0xFF);
+            vp8xData[6] = (byte)((wMinusOne >> 16) & 0xFF);
+            vp8xData[7] = (byte)(hMinusOne & 0xFF);
+            vp8xData[8] = (byte)((hMinusOne >> 8) & 0xFF);
+            vp8xData[9] = (byte)((hMinusOne >> 16) & 0xFF);
+
+            chunks.Insert(0, new WebpChunk("VP8X", vp8xData));
+        }
+
+        chunks.RemoveAll(c => c.FourCC == "XMP ");
+        chunks.Add(new WebpChunk("XMP ", Encoding.UTF8.GetBytes(xmpXml)));
+
+        using (var ms = new MemoryStream())
+        {
+            ms.Write(Encoding.ASCII.GetBytes("RIFF"), 0, 4);
+            ms.Write(new byte[4], 0, 4); // File size placeholder
+            ms.Write(Encoding.ASCII.GetBytes("WEBP"), 0, 4);
+
+            foreach (var chunk in chunks)
+            {
+                byte[] fccBytes = Encoding.ASCII.GetBytes(chunk.FourCC);
+                byte[] lenBytes = BitConverter.GetBytes((uint)chunk.Data.Length);
+                ms.Write(fccBytes, 0, 4);
+                ms.Write(lenBytes, 0, 4);
+                ms.Write(chunk.Data, 0, chunk.Data.Length);
+                if ((chunk.Data.Length & 1) != 0)
+                {
+                    ms.WriteByte(0);
+                }
+            }
+
+            byte[] finalBytes = ms.ToArray();
+            uint finalSize = (uint)finalBytes.Length - 8;
+            byte[] sizeBytes = BitConverter.GetBytes(finalSize);
+            Buffer.BlockCopy(sizeBytes, 0, finalBytes, 4, 4);
+
+            return finalBytes;
+        }
+    }
+}

--- a/Patches/PhotoMetadataPatch.cs
+++ b/Patches/PhotoMetadataPatch.cs
@@ -1,4 +1,4 @@
-﻿using Elements.Assets;
+using Elements.Assets;
 using Elements.Core;
 using FreeImageAPI;
 using FrooxEngine;
@@ -72,44 +72,155 @@ public partial class ResoniteScreenshotExtensions : ResoniteMod
             }
         }
 
+        static FREE_IMAGE_FORMAT GetFIF(ImageFormat format)
+        {
+            return format switch
+            {
+                ImageFormat.JPEG => FREE_IMAGE_FORMAT.FIF_JPEG,
+                ImageFormat.WEBP => FreeImage.GetFIFFromFormat("webp"),
+                ImageFormat.PNG => FREE_IMAGE_FORMAT.FIF_PNG,
+                _ => FREE_IMAGE_FORMAT.FIF_JPEG
+            };
+        }
+
+        static FREE_IMAGE_SAVE_FLAGS GetSaveFlags(ImageFormat format)
+        {
+            return format switch
+            {
+                ImageFormat.JPEG => (FREE_IMAGE_SAVE_FLAGS)95 | FREE_IMAGE_SAVE_FLAGS.JPEG_SUBSAMPLING_444 | FREE_IMAGE_SAVE_FLAGS.JPEG_PROGRESSIVE,
+                ImageFormat.WEBP => (_config?.GetValue(LossyWebpKey) ?? false) ? (FREE_IMAGE_SAVE_FLAGS)_config.GetValue(LossyWebpQualityKey) : FREE_IMAGE_SAVE_FLAGS.WEBP_LOSSLESS,
+                ImageFormat.PNG => (FREE_IMAGE_SAVE_FLAGS)4,
+                _ => FREE_IMAGE_SAVE_FLAGS.DEFAULT
+            };
+        }
+
         static void SaveImage(Metadata metadata, string srcPath, string dstPath, ImageFormat format)
         {
-            using (var bmp = new FreeImageBitmap(srcPath))
+            bool shouldSaveMetadata = _config?.GetValue(SavePhotoMetadataToFileKey) ?? false;
+            bool isLinux = System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Linux);
+
+            try
             {
-                if (_config?.GetValue(SavePhotoMetadataToFileKey) ?? false)
-                {
-                    XmpMetadata.UpsertPhotoMetadata(bmp, metadata);
-                }
+                string srcExt = Path.GetExtension(srcPath).ToLower();
+                string dstExt = Path.GetExtension(dstPath).ToLower();
+                bool formatsMatch = (srcExt == ".jpg" && dstExt == ".jpg") ||
+                                    (srcExt == ".jpeg" && dstExt == ".jpg") ||
+                                    (srcExt == ".png" && dstExt == ".png") ||
+                                    (srcExt == ".webp" && dstExt == ".webp");
 
-                // EnsureNonHDR
-                var imgType = bmp.ImageType;
-                if (imgType == FREE_IMAGE_TYPE.FIT_RGBF || imgType == FREE_IMAGE_TYPE.FIT_RGBAF)
+                if (isLinux && formatsMatch)
                 {
-                    bmp.TmoDrago03(0, 0);
-                }
-
-                // TextureEncoder.ConvertToJPG と同じ処理
-                if (format == ImageFormat.JPEG)
-                {
-                    // Ensure24BPP
-                    if (bmp.IsTransparent || bmp.ColorDepth > 24)
+                    if (shouldSaveMetadata)
                     {
-                        bmp.ConvertColorDepth(FREE_IMAGE_COLOR_DEPTH.FICD_24_BPP);
+                        int width, height;
+                        bool isTransparent;
+                        using (var bmp = new FreeImageBitmap(srcPath))
+                        {
+                            width = bmp.Width;
+                            height = bmp.Height;
+                            isTransparent = bmp.IsTransparent;
+                        }
+                        byte[] origBytes = File.ReadAllBytes(srcPath);
+                        byte[] injected = MetadataInjector.InjectXmp(origBytes, format, metadata, width, height, isTransparent);
+                        File.WriteAllBytes(dstPath, injected);
+                    }
+                    else
+                    {
+                        File.Copy(srcPath, dstPath, true);
+                    }
+                    return;
+                }
+            }
+            catch (Exception ex)
+            {
+                Msg($"Fast copy directly failed: {ex.Message}. Falling back to full pipeline.");
+            }
+
+            try
+            {
+                using (var bmp = new FreeImageBitmap(srcPath))
+                {
+                    int width = bmp.Width;
+                    int height = bmp.Height;
+                    bool isTransparent = bmp.IsTransparent;
+
+                    var imgType = bmp.ImageType;
+                    if (imgType == FREE_IMAGE_TYPE.FIT_RGBF || imgType == FREE_IMAGE_TYPE.FIT_RGBAF)
+                    {
+                        bmp.TmoDrago03(0, 0);
+                    }
+
+                    if (format == ImageFormat.JPEG)
+                    {
+                        if (bmp.IsTransparent || bmp.ColorDepth > 24)
+                        {
+                            bmp.ConvertColorDepth(FREE_IMAGE_COLOR_DEPTH.FICD_24_BPP);
+                        }
+                    }
+
+                    if (isLinux)
+                    {
+                        byte[] finalBytes;
+                        using (var ms = new MemoryStream())
+                        {
+                            bmp.Save(ms, GetFIF(format), GetSaveFlags(format));
+                            finalBytes = ms.ToArray();
+                        }
+
+                        if (shouldSaveMetadata)
+                        {
+                            finalBytes = MetadataInjector.InjectXmp(finalBytes, format, metadata, width, height, isTransparent);
+                        }
+
+                        File.WriteAllBytes(dstPath, finalBytes);
+                    }
+                    else
+                    {
+                        if (shouldSaveMetadata)
+                        {
+                            XmpMetadata.UpsertPhotoMetadata(bmp, metadata);
+                        }
+                        bmp.Save(dstPath, GetFIF(format), GetSaveFlags(format));
                     }
                 }
-
-                switch (format)
+            }
+            catch (Exception ex)
+            {
+                if (isLinux)
                 {
-                    case ImageFormat.JPEG:
-                        bmp.Save(dstPath, FREE_IMAGE_FORMAT.FIF_JPEG, (FREE_IMAGE_SAVE_FLAGS)95 | FREE_IMAGE_SAVE_FLAGS.JPEG_SUBSAMPLING_444 | FREE_IMAGE_SAVE_FLAGS.JPEG_PROGRESSIVE);
-                        break;
-                    case ImageFormat.WEBP:
-                        FREE_IMAGE_SAVE_FLAGS quality = (_config?.GetValue(LossyWebpKey) ?? false) ? (FREE_IMAGE_SAVE_FLAGS)_config.GetValue(LossyWebpQualityKey) : FREE_IMAGE_SAVE_FLAGS.WEBP_LOSSLESS;
-                        bmp.Save(dstPath, FreeImage.GetFIFFromFormat("webp"), quality);
-                        break;
-                    case ImageFormat.PNG:
-                        bmp.Save(dstPath, FREE_IMAGE_FORMAT.FIF_PNG, (FREE_IMAGE_SAVE_FLAGS)4);
-                        break;
+                    Msg($"FreeImage conversion failed: {ex.Message}. Copying original format file instead.");
+                    string srcExt = Path.GetExtension(srcPath).ToLower();
+                    string realDstPath = Path.ChangeExtension(dstPath, srcExt);
+
+                    if (shouldSaveMetadata)
+                    {
+                        int width, height;
+                        bool isTransparent;
+                        using (var bmp = new FreeImageBitmap(srcPath))
+                        {
+                            width = bmp.Width;
+                            height = bmp.Height;
+                            isTransparent = bmp.IsTransparent;
+                        }
+                        byte[] origBytes = File.ReadAllBytes(srcPath);
+                        byte[] injected = MetadataInjector.InjectXmp(origBytes, srcExt switch
+                        {
+                            ".jpg" => ImageFormat.JPEG,
+                            ".jpeg" => ImageFormat.JPEG,
+                            ".png" => ImageFormat.PNG,
+                            ".webp" => ImageFormat.WEBP,
+                            _ => format
+                        }, metadata, width, height, isTransparent);
+                        File.WriteAllBytes(realDstPath, injected);
+                    }
+                    else
+                    {
+                        File.Copy(srcPath, realDstPath, true);
+                    }
+                }
+                else
+                {
+                    throw;
                 }
             }
 
@@ -144,7 +255,20 @@ public partial class ResoniteScreenshotExtensions : ResoniteMod
                     var tmpPath = await engine.AssetManager.GatherAssetFile(url, 100f);
                     if (tmpPath is null) return;
 
-                    string pictures = Environment.GetFolderPath(Environment.SpecialFolder.MyPictures);
+                    string pictures = _config?.GetValue(CustomSavePathKey) ?? "";
+                    if (string.IsNullOrWhiteSpace(pictures))
+                    {
+                        pictures = Environment.GetFolderPath(Environment.SpecialFolder.MyPictures);
+                    }
+                    if (string.IsNullOrWhiteSpace(pictures))
+                    {
+                        pictures = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                    }
+                    if (string.IsNullOrWhiteSpace(pictures))
+                    {
+                        pictures = AppContext.BaseDirectory;
+                    }
+
                     pictures = Path.Combine(pictures, engine.Cloud.Platform.Name);
                     if (_config?.GetValue(DigFolderWhenSavingKey) ?? false)
                     {
@@ -183,6 +307,8 @@ public partial class ResoniteScreenshotExtensions : ResoniteMod
                         }
                         while (File.Exists(str1));
 
+                        Msg($"Saving screenshot to: {str1}");
+
                         if (_keepOriginalScreenshotFormat)
                         {
                             if (extension != ".jpg" && extension != ".webp" && extension != ".png")
@@ -210,9 +336,9 @@ public partial class ResoniteScreenshotExtensions : ResoniteMod
                     }
                     catch (Exception ex)
                     {
-                        Error("Exception saving screenshot to Windows:\n" + ex);
+                        Error("Exception saving screenshot:\n" + ex);
                         _config?.Set(EnabledKey, false);
-                        NotificationMessage.SpawnTextMessage("[ScreenshotExtensions] Failed saving screenshot!", colorX.Red);
+                        NotificationMessage.SpawnTextMessage($"[ScreenshotExtensions] Failed saving screenshot: {ex.Message}", colorX.Red);
                     }
                     finally
                     {
@@ -221,9 +347,9 @@ public partial class ResoniteScreenshotExtensions : ResoniteMod
                 }
                 catch (Exception ex)
                 {
-                    Error("Exception saving screenshot to Windows:\n" + ex);
+                    Error("Exception saving screenshot:\n" + ex);
                     _config.Set(EnabledKey, false);
-                    NotificationMessage.SpawnTextMessage("[ScreenshotExtensions] Failed saving screenshot!", colorX.Red);
+                    NotificationMessage.SpawnTextMessage($"[ScreenshotExtensions] Failed saving screenshot: {ex.Message}", colorX.Red);
                 }
             });
         }
@@ -243,7 +369,7 @@ public partial class ResoniteScreenshotExtensions : ResoniteMod
             }
             item.Button.LocalPressed += (button, eventData) =>
             {
-                __instance.LocalUser.CloseContextMenu(null);
+                __instance.LocalUser.CloseContextMenu(null!);
                 Msg("Posting to Discord...");
                 __instance.StartGlobalTask(async () =>
                 {

--- a/Patches/PhotoMetadataPatch.cs
+++ b/Patches/PhotoMetadataPatch.cs
@@ -108,7 +108,7 @@ public partial class ResoniteScreenshotExtensions : ResoniteMod
                                     (srcExt == ".png" && dstExt == ".png") ||
                                     (srcExt == ".webp" && dstExt == ".webp");
 
-                if (isLinux && formatsMatch)
+                if (formatsMatch)
                 {
                     if (shouldSaveMetadata)
                     {
@@ -158,30 +158,19 @@ public partial class ResoniteScreenshotExtensions : ResoniteMod
                         }
                     }
 
-                    if (isLinux)
+                    byte[] finalBytes;
+                    using (var ms = new MemoryStream())
                     {
-                        byte[] finalBytes;
-                        using (var ms = new MemoryStream())
-                        {
-                            bmp.Save(ms, GetFIF(format), GetSaveFlags(format));
-                            finalBytes = ms.ToArray();
-                        }
-
-                        if (shouldSaveMetadata)
-                        {
-                            finalBytes = MetadataInjector.InjectXmp(finalBytes, format, metadata, width, height, isTransparent);
-                        }
-
-                        File.WriteAllBytes(dstPath, finalBytes);
+                        bmp.Save(ms, GetFIF(format), GetSaveFlags(format));
+                        finalBytes = ms.ToArray();
                     }
-                    else
+
+                    if (shouldSaveMetadata)
                     {
-                        if (shouldSaveMetadata)
-                        {
-                            XmpMetadata.UpsertPhotoMetadata(bmp, metadata);
-                        }
-                        bmp.Save(dstPath, GetFIF(format), GetSaveFlags(format));
+                        finalBytes = MetadataInjector.InjectXmp(finalBytes, format, metadata, width, height, isTransparent);
                     }
+
+                    File.WriteAllBytes(dstPath, finalBytes);
                 }
             }
             catch (Exception ex)

--- a/ResoniteScreenshotExtensions.cs
+++ b/ResoniteScreenshotExtensions.cs
@@ -1,4 +1,4 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using ResoniteModLoader;
 
 namespace ResoniteScreenshotExtensions;
@@ -28,6 +28,9 @@ public partial class ResoniteScreenshotExtensions : ResoniteMod
     [AutoRegisterConfigKey]
     public static readonly ModConfigurationKey<bool> LoadPhotoMetadataFromFileKey =
         new ModConfigurationKey<bool>("LoadPhotoMetadataFromFile", "Load PhotoMetadata from file", () => true);
+    [AutoRegisterConfigKey]
+    public static readonly ModConfigurationKey<string> CustomSavePathKey =
+        new ModConfigurationKey<string>("CustomSavePath", "Custom save path (leave empty for default Pictures folder)", () => "");
     [AutoRegisterConfigKey]
     public static readonly ModConfigurationKey<bool> DigFolderWhenSavingKey =
         new ModConfigurationKey<bool>("DigFolderWhenSaving", "Dig the folder by month and date when saving", () => true);

--- a/ResoniteScreenshotExtensions.cs
+++ b/ResoniteScreenshotExtensions.cs
@@ -7,7 +7,7 @@ public partial class ResoniteScreenshotExtensions : ResoniteMod
 {
     public override string Name => "ResoniteScreenshotExtensions";
     public override string Author => "hantabaru1014";
-    public override string Version => "2.1.1";
+    public override string Version => "2.2.0";
     public override string Link => "https://github.com/hantabaru1014/ResoniteScreenshotExtensions";
 
     [AutoRegisterConfigKey]

--- a/ResoniteScreenshotExtensions.csproj
+++ b/ResoniteScreenshotExtensions.csproj
@@ -1,14 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
     <AppName>Resonite</AppName>
-	  <ModLoaderShort>rml</ModLoaderShort>
+    <ModLoaderShort>rml</ModLoaderShort>
     <AppPath>$(MSBuildThisFileDirectory)$(AppName)</AppPath>
+    
     <AppPath Condition="Exists('C:\Program Files (x86)\Steam\steamapps\common\$(AppName)\')">C:\Program Files (x86)\Steam\steamapps\common\$(AppName)\</AppPath>
+    
     <AppPath Condition="Exists('$(HOME)/.steam/steam/steamapps/common/$(AppName)/')">$(HOME)/.steam/steam/steamapps/common/$(AppName)/</AppPath>
+    
+    <AppPath Condition="Exists('$(HOME)/.var/app/com.valvesoftware.Steam/.local/share/Steam/steamapps/common/$(AppName)/')">$(HOME)/.var/app/com.valvesoftware.Steam/.local/share/Steam/steamapps/common/$(AppName)/</AppPath>
+    
     <CopyLocal>false</CopyLocal>
     <CopyToMods Condition="'$(CopyToMods)'==''">true</CopyToMods>
     <DebugSymbols Condition="'$(Configuration)'=='Release'">false</DebugSymbols>
@@ -19,46 +24,53 @@
 
   <ItemGroup>
     <Reference Include="HarmonyLib">
-      <HintPath>$(AppPath)$(ModLoaderShort)_libs\0Harmony.dll</HintPath>
+      <HintPath>$(AppPath)$(ModLoaderShort)_libs/0Harmony.dll</HintPath>
       <HintPath Condition="Exists('$(AppPath)0Harmony.dll')">$(AppPath)0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="$(AppName)ModLoader">
       <HintPath>$(AppPath)$(AppName)ModLoader.dll</HintPath>
-      <HintPath>$(AppPath)Libraries\$(AppName)ModLoader.dll</HintPath>
+      <HintPath>$(AppPath)Libraries/$(AppName)ModLoader.dll</HintPath>
     </Reference>
     <Reference Include="FrooxEngine">
-      <HintPath>$(AppPath)\FrooxEngine.dll</HintPath>
+      <HintPath>$(AppPath)Resonite_Data/Managed/FrooxEngine.dll</HintPath>
+      <HintPath Condition="Exists('$(AppPath)FrooxEngine.dll')">$(AppPath)FrooxEngine.dll</HintPath>
     </Reference>
     <Reference Include="FrooxEngine.Store">
-      <HintPath>$(AppPath)\FrooxEngine.Store.dll</HintPath>
+      <HintPath>$(AppPath)Resonite_Data/Managed/FrooxEngine.Store.dll</HintPath>
+      <HintPath Condition="Exists('$(AppPath)FrooxEngine.Store.dll')">$(AppPath)FrooxEngine.Store.dll</HintPath>
     </Reference>
     <Reference Include="Elements.Core">
-      <HintPath>$(AppPath)\Elements.Core.dll</HintPath>
+      <HintPath>$(AppPath)Resonite_Data/Managed/Elements.Core.dll</HintPath>
+      <HintPath Condition="Exists('$(AppPath)Elements.Core.dll')">$(AppPath)Elements.Core.dll</HintPath>
     </Reference>
     <Reference Include="Elements.Assets">
-      <HintPath>$(AppPath)\Elements.Assets.dll</HintPath>
+      <HintPath>$(AppPath)Resonite_Data/Managed/Elements.Assets.dll</HintPath>
+      <HintPath Condition="Exists('$(AppPath)Elements.Assets.dll')">$(AppPath)Elements.Assets.dll</HintPath>
     </Reference>
     <Reference Include="Elements.Data">
-      <HintPath>$(AppPath)\Elements.Data.dll</HintPath>
+      <HintPath>$(AppPath)Resonite_Data/Managed/Elements.Data.dll</HintPath>
+      <HintPath Condition="Exists('$(AppPath)Elements.Data.dll')">$(AppPath)Elements.Data.dll</HintPath>
     </Reference>
     <Reference Include="SkyFrost.Base">
-      <HintPath>$(AppPath)\SkyFrost.Base.dll</HintPath>
+      <HintPath>$(AppPath)Resonite_Data/Managed/SkyFrost.Base.dll</HintPath>
+      <HintPath Condition="Exists('$(AppPath)SkyFrost.Base.dll')">$(AppPath)SkyFrost.Base.dll</HintPath>
     </Reference>
     <Reference Include="SkyFrost.Base.Models">
-      <HintPath>$(AppPath)\SkyFrost.Base.Models.dll</HintPath>
+      <HintPath>$(AppPath)Resonite_Data/Managed/SkyFrost.Base.Models.dll</HintPath>
+      <HintPath Condition="Exists('$(AppPath)SkyFrost.Base.Models.dll')">$(AppPath)SkyFrost.Base.Models.dll</HintPath>
     </Reference>
     <Reference Include="MimeDetective">
-      <HintPath>$(AppPath)\MimeDetective.dll</HintPath>
+      <HintPath>$(AppPath)Resonite_Data/Managed/MimeDetective.dll</HintPath>
+      <HintPath Condition="Exists('$(AppPath)MimeDetective.dll')">$(AppPath)MimeDetective.dll</HintPath>
     </Reference>
     <Reference Include="FreeImageNET">
-      <HintPath>$(AppPath)\FreeImageNET.dll</HintPath>
+      <HintPath>$(AppPath)Resonite_Data/Managed/FreeImageNET.dll</HintPath>
+      <HintPath Condition="Exists('$(AppPath)FreeImageNET.dll')">$(AppPath)FreeImageNET.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>$(AppPath)\Newtonsoft.Json.dll</HintPath>
+      <HintPath>$(AppPath)Resonite_Data/Managed/Newtonsoft.Json.dll</HintPath>
+      <HintPath Condition="Exists('$(AppPath)Newtonsoft.Json.dll')">$(AppPath)Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" />
-    <PackageReference Include="System.Xml.Linq" />
     <PackageReference Include="System.Drawing.Common" Version="9.0.8" />
   </ItemGroup>
 

--- a/ResoniteScreenshotExtensions.csproj
+++ b/ResoniteScreenshotExtensions.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>net10.0</TargetFramework>
@@ -18,7 +18,7 @@
     <CopyToMods Condition="'$(CopyToMods)'==''">true</CopyToMods>
     <DebugSymbols Condition="'$(Configuration)'=='Release'">false</DebugSymbols>
     <DebugType Condition="'$(Configuration)'=='Release'">None</DebugType>
-    <Version>2.1.1</Version>
+    <Version>2.2.0</Version>
     <Authors>hantabaru1014</Authors>
   </PropertyGroup>
 

--- a/XmpMetadata.cs
+++ b/XmpMetadata.cs
@@ -1,4 +1,4 @@
-﻿using FreeImageAPI;
+using FreeImageAPI;
 using System.Xml.Linq;
 using FrooxEngine;
 using FreeImageAPI.Metadata;
@@ -20,7 +20,8 @@ public static class XmpMetadata
 
     static string EscapeUnicode(string str)
     {
-        return Regex.Replace(str, @"\\u", "\\\\u").Select(c => {
+        return Regex.Replace(str, @"\\u", "\\\\u").Select(c =>
+        {
             if (c > 0x7F)
             {
                 return "\\u" + ((int)c).ToString("X4");
@@ -36,7 +37,7 @@ public static class XmpMetadata
         return Regex.Replace(decoded, @"\\\\u", "\\u");
     }
 
-    static XElement ParseOrDefaultXmp(string xmlStr)
+    static XElement ParseOrDefaultXmp(string? xmlStr)
     {
         if (string.IsNullOrEmpty(xmlStr))
         {
@@ -112,7 +113,7 @@ public static class XmpMetadata
         }
 
         var user = DeserializeMetadataUser(element);
-        
+
         return new MetadataUserInfo(
             User: user,
             IsInVR: bool.Parse(GetAttribute("UI-IsInVR")),
@@ -231,18 +232,18 @@ public static class XmpMetadata
             LocationHost: DeserializeMetadataUser(locationHostElement),
             LocationAccessLevel: accessLevel,
             LocationHiddenFromListing: hidden,
-            TimeTaken: DateTime.Parse(GetAttribute("TimeTaken", false)),
+            TimeTaken: DateTime.Parse(GetAttribute("TimeTaken", false)!),
             TakenBy: DeserializeMetadataUser(takenByElement),
-            TakenGlobalPosition: float3.Parse(GetAttribute("TakenGlobalPosition", false)),
-            TakenGlobalRotation: floatQ.Parse(GetAttribute("TakenGlobalRotation", false)),
-            TakenGlobalScale: float3.Parse(GetAttribute("TakenGlobalScale", false)),
+            TakenGlobalPosition: float3.Parse(GetAttribute("TakenGlobalPosition", false)!),
+            TakenGlobalRotation: floatQ.Parse(GetAttribute("TakenGlobalRotation", false)!),
+            TakenGlobalScale: float3.Parse(GetAttribute("TakenGlobalScale", false)!),
             AppVersion: GetAttributeStr("AppVersion", false)!,
             UserInfos: userInfos,
             CameraManufacturer: GetAttributeStr("CameraManufacturer", false)!,
             CameraModel: GetAttributeStr("CameraModel", false)!,
-            CameraFOV: float.Parse(GetAttribute("CameraFOV", false)),
-            Is360: bool.Parse(GetAttribute("Is360", false)),
-            StereoLayout: (StereoLayout)Enum.Parse(typeof(StereoLayout), GetAttribute("StereoLayout", false))
+            CameraFOV: float.Parse(GetAttribute("CameraFOV", false)!),
+            Is360: bool.Parse(GetAttribute("Is360", false)!),
+            StereoLayout: (StereoLayout)Enum.Parse(typeof(StereoLayout), GetAttribute("StereoLayout", false)!)
         );
     }
 
@@ -259,7 +260,7 @@ public static class XmpMetadata
 
         SerializeMetadata(description, metadata);
 
-        rdf.Add(description);
+        rdf!.Add(description);
     }
 
     public static void UpsertPhotoMetadata(FreeImageBitmap bmp, Metadata metadata)
@@ -272,6 +273,13 @@ public static class XmpMetadata
         AddRdfDescription(xmpRoot, metadata);
 
         xmpMeta.Xml = "<?xpacket begin=\"\ufeff\"?>" + xmpRoot.ToString(SaveOptions.DisableFormatting) + "<?xpacket end=\"w\"?>";
+    }
+
+    public static string GetXmpXmlString(Metadata metadata)
+    {
+        var xmpRoot = ParseOrDefaultXmp(null);
+        AddRdfDescription(xmpRoot, metadata);
+        return "<?xpacket begin=\"\ufeff\"?>" + xmpRoot.ToString(SaveOptions.DisableFormatting) + "<?xpacket end=\"w\"?>";
     }
 
     static bool TryLoadV1Json(XElement xmpRoot, out string json)


### PR DESCRIPTION
Hey! Love this mod and wanted to get it working on Linux, whether on native or Flatpak steam.

Right now, FreeImage's native metadata writing and path saves freeze/crash on Linux due to native path marshalling bugs. I fixed this by adding a custom `MetadataInjector` that inserts the XMP packet (`JPEG`, `PNG`, `WebP`) completely in-memory before writing to disk. This way, we still only write to disk once.

While I was at it, I also:
- Consolidated the `SaveImage` method to clean up redundant blocks.
- Fixed 9 compiler nullability warnings.
- Added a `CustomSavePath` setting so Flatpak users can direct saves outside their read-only sandboxed pictures folder.
- Kept the Windows paths using native FreeImage saving so nothing changes there.
- Ran dotnet format.

Let me know if you want any adjustments!